### PR TITLE
Update GitHub repository link in acknowledgements page

### DIFF
--- a/app/acknowledgements/page.tsx
+++ b/app/acknowledgements/page.tsx
@@ -52,7 +52,7 @@ export default function AcknowledgementsPage() {
           </CardHeader>
           <CardContent className="space-y-2">
             <Link
-              href="https://github.com/rrcoder0167/lets-assist"
+              href="https://github.com/riddhimanrana/lets-assist"
               className="text-chart-3 font-semibold"
             >
               lets-assist


### PR DESCRIPTION
This pull request includes a minor update to the `AcknowledgementsPage` component. The change updates the GitHub repository link to reflect the correct username for the `lets-assist` project.

* [`app/acknowledgements/page.tsx`](diffhunk://#diff-36e9221574a2b8c6bad97bcb57ad645765d5942d17178d9a01b7f5d707d55db8L55-R55): Updated the `href` attribute of the `Link` component to point to `https://github.com/riddhimanrana/lets-assist` instead of the previous incorrect URL.