### PR TITLE
feat: Add remote pattern for api.lets-assist.com to support image loa…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -31,6 +31,11 @@ const nextConfig = {
         hostname: "fotdmeakexgrkronxlof.supabase.co",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "api.lets-assist.com", // supabase custom domain
+        pathname: "/**",
+      }
     ],
   },
   experimental: {


### PR DESCRIPTION
This pull request adds support for an additional Supabase custom domain to the Next.js configuration. The change ensures that requests to `api.lets-assist.com` are now permitted, which may be necessary for production or custom deployments.

* Added a new remote pattern to `next.config.mjs` to allow requests to `api.lets-assist.com`, supporting the Supabase custom domain.