### PR TITLE
refactor: Comment out Google Fonts import in email HTML templates

### DIFF
--- a/app/api/auto-publish-hours/route.ts
+++ b/app/api/auto-publish-hours/route.ts
@@ -64,7 +64,7 @@ function generateCertificatePublishedEmailHtml(
       <meta charset="UTF-8">
       <title>Your Volunteer Certificate is Ready!</title>
       <style>
-          @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+          // @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
           * {
               margin: 0;

--- a/app/projects/[id]/actions.ts
+++ b/app/projects/[id]/actions.ts
@@ -44,7 +44,7 @@ const generateConfirmationEmailHtml = (
       <meta charset="UTF-8">
       <title>Confirm Your Signup</title>
       <style>
-          @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;of 5 00;600;700&display=swap');
+          // @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
           * {
               margin: 0;
@@ -167,7 +167,7 @@ const generateLoggedInUserConfirmationEmailHtml = (
       <meta charset="UTF-8">
       <title>Signup Confirmed</title>
       <style>
-          @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+          // @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
           * {
               margin: 0;

--- a/app/projects/[id]/hours/actions.ts
+++ b/app/projects/[id]/hours/actions.ts
@@ -48,7 +48,7 @@ const generateCertificatePublishedEmailHtml = (
       <meta charset="UTF-8">
       <title>Your Volunteer Certificate is Ready!</title>
       <style>
-          @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+          // @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
           * {
               margin: 0;


### PR DESCRIPTION
This pull request comments out the `@import` statement for the Inter font in several HTML email templates. This change is likely to improve email client compatibility, as many email clients do not support external font imports in `<style>` tags.

Email template updates:

* Commented out the Google Fonts `@import` for the Inter font in the certificate published email HTML in `app/api/auto-publish-hours/route.ts`.
* Commented out the Google Fonts `@import` for the Inter font in the confirmation and signup confirmation email HTML templates in `app/projects/[id]/actions.ts`. ([app/projects/[id]/actions.tsL47-R47](diffhunk://#diff-d34236c8a46e62dff59c17fcea0bd3904d33bf1b8bf564e50519032c040b50e0L47-R47), [app/projects/[id]/actions.tsL170-R170](diffhunk://#diff-d34236c8a46e62dff59c17fcea0bd3904d33bf1b8bf564e50519032c040b50e0L170-R170))
* Commented out the Google Fonts `@import` for the Inter font in the certificate published email HTML in `app/projects/[id]/hours/actions.ts`. ([app/projects/[id]/hours/actions.tsL51-R51](diffhunk://#diff-46e9ef8f36650663e0a549a17cae369c034f237ba458d039754a47af22eb8550L51-R51))